### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Arduino library for the MAX1067 14-bit ADC
 paragraph=Arduino library for the MAX1067 14-bit ADC
 category=Sensors
 url=https://github.com/Erik-k/
-architectures=Uno
+architectures=avr


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library MAX1067 claims to run on (ARCHITECTURE) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.